### PR TITLE
feat : 추천 강의 목록 조회 api 구현 및 Tag, Category 연관관계 추가

### DIFF
--- a/src/main/java/com/rudolph/Weevo/course/controller/CourseController.java
+++ b/src/main/java/com/rudolph/Weevo/course/controller/CourseController.java
@@ -124,5 +124,15 @@ public class CourseController {
         return ApiResponse.onSuccess(SuccessStatus._OK, myBookmarkCourses);
     }
 
+    // 11) 추천 강의 목록 조회
+    @GetMapping("/recommend")
+    public ResponseEntity<ApiResponse<PagedCourseResponse>> getRecommendCourses(
+            @AuthenticationPrincipal CustomUserPrincipal user,
+            Pageable pageable) {
+
+        PagedCourseResponse resp = courseService.getRecommend(user.getMemberId(), pageable);
+        return ApiResponse.onSuccess(SuccessStatus._OK, resp);
+    }
+
 }
 

--- a/src/main/java/com/rudolph/Weevo/course/repository/CourseRepository.java
+++ b/src/main/java/com/rudolph/Weevo/course/repository/CourseRepository.java
@@ -1,8 +1,12 @@
 package com.rudolph.Weevo.course.repository;
 
 import com.rudolph.Weevo.course.domain.Course;
+import com.rudolph.Weevo.course.domain.enums.CourseCategory;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
 
+import java.util.List;
+
 public interface CourseRepository extends JpaRepository<Course, Long>, JpaSpecificationExecutor<Course> {
+    List<Course> findAllByCourseCategoryIn(List<CourseCategory> categories);
 }

--- a/src/main/java/com/rudolph/Weevo/course/service/CourseService.java
+++ b/src/main/java/com/rudolph/Weevo/course/service/CourseService.java
@@ -1,5 +1,6 @@
 package com.rudolph.Weevo.course.service;
 
+import com.rudolph.Weevo.course.domain.enums.CourseCategory;
 import com.rudolph.Weevo.course.dto.request.CourseSearchRequest;
 import com.rudolph.Weevo.course.dto.request.CreateCourseRequest;
 import com.rudolph.Weevo.course.dto.response.*;
@@ -297,6 +298,78 @@ public class CourseService {
         List<Course> bookmarkedCourses = bookmarkRepository.findAllBookmarkedByMemberId(memberId);
         return MyCourseListDto.from(bookmarkedCourses);
     }
+
+    // 11) 추천 강의 조회
+    @Transactional(readOnly = true)
+    public PagedCourseResponse getRecommend(Long memberId, Pageable pageable) {
+        // 1) 회원과 관심 태그 조회
+        Member member = memberService.findMember(memberId);
+        List<CourseCategory> categories = member.getInterestTags().stream()
+                .map(it -> it.getTag().getCategory())
+                .distinct()
+                .toList();
+
+        // 2) 관심 카테고리가 없으면 빈 페이지 리턴
+        if (categories.isEmpty()) {
+            return PagedCourseResponse.builder()
+                    .pageNumber(pageable.getPageNumber())
+                    .pageSize(pageable.getPageSize())
+                    .totalElements(0)
+                    .totalPages(0)
+                    .courses(Collections.emptyList())
+                    .build();
+        }
+
+        // 3) 해당 카테고리 강의 전체 조회
+        List<Course> candidates = courseRepository.findAllByCourseCategoryIn(categories);
+
+        // 4) 찜(북마크) 수 집계
+        List<Long> courseIds = candidates.stream()
+                .map(Course::getId)
+                .toList();
+        Map<Long, Long> bookmarkCountMap = bookmarkRepository.countByCourseIds(courseIds);
+
+        // 5) 썸네일 URL 맵 생성
+        Map<Long, String> thumbnailMap = candidates.stream()
+                .collect(Collectors.toMap(
+                        Course::getId,
+                        c -> c.getCourseImages().stream()
+                                .filter(CourseImage::isThumbnail)
+                                .findFirst()
+                                .map(CourseImage::getCourseImgUrl)
+                                .orElse("")
+                ));
+
+        // 6) DTO 변환 후 인기순 정렬
+        List<CourseListResponse> sorted = candidates.stream()
+                .map(c -> CourseListResponse.of(
+                        c,
+                        bookmarkCountMap.getOrDefault(c.getId(), 0L),
+                        thumbnailMap.get(c.getId())
+                ))
+                .sorted(Comparator.comparingLong(CourseListResponse::getBookmarkCount).reversed())
+                .toList();
+
+        // 7) 수동 페이징
+        int total = sorted.size();
+        int start = (int) pageable.getOffset();
+        int end = Math.min(start + pageable.getPageSize(), total);
+        List<CourseListResponse> pageItems = start >= end
+                ? Collections.emptyList()
+                : sorted.subList(start, end);
+
+        int totalPages = (int) Math.ceil((double) total / pageable.getPageSize());
+
+        // 8) 응답 빌드
+        return PagedCourseResponse.builder()
+                .pageNumber(pageable.getPageNumber())
+                .pageSize(pageable.getPageSize())
+                .totalElements(total)
+                .totalPages(totalPages)
+                .courses(pageItems)
+                .build();
+    }
+
 }
 
 

--- a/src/main/java/com/rudolph/Weevo/tag/domain/Tag.java
+++ b/src/main/java/com/rudolph/Weevo/tag/domain/Tag.java
@@ -1,5 +1,6 @@
 package com.rudolph.Weevo.tag.domain;
 
+import com.rudolph.Weevo.course.domain.enums.CourseCategory;
 import jakarta.persistence.*;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -18,6 +19,10 @@ public class Tag {
     @Column(name = "tag_id")
     private Long id;
 
-    @Column(name = "tag_name")
+    @Column(name = "tag_name", nullable = false, unique = true)
     private String name;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "category", nullable = false)
+    private CourseCategory category;
 }


### PR DESCRIPTION
## 연관 이슈

close #12 

<br/>

## 개요

추천 강의 목록 조회 api 구현 및 Tag, Category 연관관계 추가

<br/>

## 📌 구현 기능

- [x] 추천 강의 목록 조회 api 구현
- [x] Tag, Category 연관관계 추가

<br/>

## ⚠️ 어려웠던 점과 해결 과정


<br/>
  
## ⚠️ 참고 사항 및 주의할 점
(아래 부분은 지우고 작성)
- 예) 토큰 유효기간 관련 설정이 아직 미완입니다.
- 예) 비밀번호 암호화 방식은 추후 논의 필요합니다.

<br/>

```
INSERT INTO tag (tag_name, category) VALUES
  ('회화', 'ART'),
  ('조각', 'ART'),
  ('공예', 'ART'),
  ('악기', 'MUSIC'),
  ('작곡', 'MUSIC'),
  ('보컬', 'MUSIC'),
  ('영어', 'LANGUAGE'),
  ('한국어', 'LANGUAGE'),
  ('스페인어', 'LANGUAGE'),
  ('웹 개발', 'COMPUTER'),
  ('데이터', 'COMPUTER'),
  ('인공지능', 'COMPUTER'),
  ('스타일링', 'FASHION'),
  ('메이크업', 'FASHION'),
  ('헤어', 'FASHION'),
  ('PT', 'SPORTS'),
  ('요가', 'SPORTS'),
  ('필라테스', 'SPORTS');

```

Tag에 해당 SQL문 작성해서 데이터 넣어주시면 됩니다!