### PR TITLE
[FIX] 403 error 핸들링 및 access token 변수명 오타 수정

### DIFF
--- a/src/main/java/com/rudolph/Weevo/auth/service/TokenServiceImpl.java
+++ b/src/main/java/com/rudolph/Weevo/auth/service/TokenServiceImpl.java
@@ -16,7 +16,7 @@ import java.util.UUID;
 @RequiredArgsConstructor
 public class TokenServiceImpl {
 
-    @Value("${jwt.access-token.expiration-time}")
+    @Value("${jwt.access_token.expiration_time}")
     private long ACCESS_TOKEN_EXPIRATION_TIME;  //엑세스 토큰 유효시간
 
     private final RefreshTokenRepository refreshTokenRepository;

--- a/src/main/java/com/rudolph/Weevo/global/config/SecurityConfig.java
+++ b/src/main/java/com/rudolph/Weevo/global/config/SecurityConfig.java
@@ -1,5 +1,7 @@
 package com.rudolph.Weevo.global.config;
 
+import com.rudolph.Weevo.global.security.CustomAccessDeniedHandler;
+import com.rudolph.Weevo.global.security.CustomAuthEntryPoint;
 import com.rudolph.Weevo.global.util.JwtAuthenticationFilter;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -20,6 +22,8 @@ import java.util.Collections;
 public class SecurityConfig {
 
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
+    private final CustomAuthEntryPoint authEntryPoint;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
@@ -36,8 +40,13 @@ public class SecurityConfig {
                                 "/ws/**"
                         ).permitAll()
                         .anyRequest().authenticated()
-                )
-                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+                ).exceptionHandling(ex -> ex
+                        .authenticationEntryPoint(authEntryPoint)      // 401 처리
+                        .accessDeniedHandler(accessDeniedHandler)
+                );
+
+        http.addFilterBefore(jwtAuthenticationFilter,
+                UsernamePasswordAuthenticationFilter.class);
 
         return http.build();
     }

--- a/src/main/java/com/rudolph/Weevo/global/security/CustomAccessDeniedHandler.java
+++ b/src/main/java/com/rudolph/Weevo/global/security/CustomAccessDeniedHandler.java
@@ -1,0 +1,34 @@
+package com.rudolph.Weevo.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rudolph.Weevo.global.common.api.ApiResponse;
+import com.rudolph.Weevo.global.common.code.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Override
+    public void handle(HttpServletRequest req,
+                       HttpServletResponse res,
+                       AccessDeniedException ex) throws IOException {
+
+        ApiResponse<Object> body =
+                ApiResponse.onFailure(ErrorStatus._FORBIDDEN).getBody();
+
+        res.setStatus(HttpStatus.FORBIDDEN.value());
+        res.setContentType("application/json;charset=UTF-8");
+        res.getWriter().write(om.writeValueAsString(body));
+    }
+}

--- a/src/main/java/com/rudolph/Weevo/global/security/CustomAuthEntryPoint.java
+++ b/src/main/java/com/rudolph/Weevo/global/security/CustomAuthEntryPoint.java
@@ -1,0 +1,34 @@
+package com.rudolph.Weevo.global.security;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.rudolph.Weevo.global.common.api.ApiResponse;
+import com.rudolph.Weevo.global.common.code.ErrorStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class CustomAuthEntryPoint implements AuthenticationEntryPoint {
+
+    private final ObjectMapper om = new ObjectMapper();
+
+    @Override
+    public void commence(HttpServletRequest req,
+                         HttpServletResponse res,
+                         AuthenticationException ex) throws IOException {
+
+        ApiResponse<Object> body =
+                ApiResponse.onFailure(ErrorStatus._UNAUTHORIZED).getBody();
+
+        res.setStatus(HttpStatus.UNAUTHORIZED.value());
+        res.setContentType("application/json;charset=UTF-8");
+        res.getWriter().write(om.writeValueAsString(body));
+    }
+}


### PR DESCRIPTION
## 연관 이슈


<br/>

## 개요

401, 403 error 발생 시 Spring Security에서 잡아가지 않고 handler 가 캐치하도록 수정

<br/>

## 📌 구현 기능

- [ ] CustomEntryPoint 진입점 설정
- [ ] CustomAccessDeniedHandler 설정

<br/>

